### PR TITLE
Blank when first launch the app

### DIFF
--- a/best_flutter_ui_templates/lib/main.dart
+++ b/best_flutter_ui_templates/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'navigationHomeScreen.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
   SystemChrome.setPreferredOrientations(
           [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown])
       .then((_) => runApp(new MyApp()));


### PR DESCRIPTION
# Follow is the error log
If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.