### PR TITLE
Fixing Drawer issue #37

### DIFF
--- a/best_flutter_ui_templates/lib/custom_drawer/drawer_user_controller.dart
+++ b/best_flutter_ui_templates/lib/custom_drawer/drawer_user_controller.dart
@@ -51,10 +51,10 @@ class _DrawerUserControllerState extends State<DrawerUserController> with Ticker
             });
           }
           iconAnimationController.animateTo(0.0, duration: const Duration(milliseconds: 0), curve: Curves.fastOutSlowIn);
-        } else if (scrollController.offset > 0 && scrollController.offset < widget.drawerWidth) {
+        } else if (scrollController.offset > 0 && scrollController.offset < widget.drawerWidth.floor()) {
           iconAnimationController.animateTo((scrollController.offset * 100 / (widget.drawerWidth)) / 100,
               duration: const Duration(milliseconds: 0), curve: Curves.fastOutSlowIn);
-        } else if (scrollController.offset <= widget.drawerWidth) {
+        } else {
           if (scrolloffset != 0.0) {
             setState(() {
               scrolloffset = 0.0;


### PR DESCRIPTION
As the issue states, the drawer was opening when it shouldn't. The problem was that sometimes there was a minute difference between scrollController.offset and widget.drawerWidth (294.54545454545456 and 294.54545454545455, in my case), and thus the correct function was not being executed. I have changed the > < if condition when adding the Listener to scrollController to compare with the floor value instead, (294, in my case). Since the change is quite less, I figure this should work fine :)