### PR TITLE
Updated sdk to v2.8.0 in pubspec.yaml

### DIFF
--- a/best_flutter_ui_templates/pubspec.yaml
+++ b/best_flutter_ui_templates/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.8.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Looks like a change in Dart now requires sdk v2.8.0 in order to suppress an error in the AnimationController on the vsync parameter.
Using the >2.7.0 sdk results in an error: The named parameter 'vsync' isn't defined.
Ref: https://github.com/flutter/flutter/issues/62752#issuecomment-667744745